### PR TITLE
Query for current state senators and representatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 
 node_modules/
 
+# Linting
+
+.jshintrc
+.tern-project
+
 # Project-specific
 
 production_config.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
         - alpha
     only:
         - master
+        - congress
 env:
     - CXX=g++-4.8 NODE_ENV=test
 addons:

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ https://github.com/jrrembert/elected-official-rest-api.git
 The site only serves content over HTTPS so you will need to generate a self-signed certificate. Instructions use openssl, but other methods work as well.
 
 1. Generate a private key
-  
+
   ```
   $ openssl genrsa -des3 -out server.key 1024
   ```
 
 2. Generate a Certificate Signing Request
-  
+
   ```
   $ openssl req -new -key server.key -out server.csr
   ```
 
 3. Generate Self-Signed Cert
-  
+
   ```
   $ openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
   ```
 
 4. (Optional) Remove passphrase from key. This is useful for running in development.
-  
+
   ```
   $ openssl rsa -in server.key -out new_server.key && mv new_server.key server.key
   ```
@@ -104,4 +104,10 @@ Response Body:
     "Tim Scott"
   ]
 }
+```
+
+## Tests
+
+```bash
+NODE_ENV=test mocha path/to/tests.py
 ```

--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,7 @@ app.use(function(req, res, next) {
 app.get('/', routes.appRoot);
 app.get('/v1/governors', routes.getGovernors);
 app.get('/v1/governors/:id', routes.getGovernorById);
+app.get('/v1/congress', routes.getCongressMembers);
 
 // Catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/src/app.js
+++ b/src/app.js
@@ -31,6 +31,7 @@ app.get('/', routes.appRoot);
 app.get('/v1/governors', routes.getGovernors);
 app.get('/v1/governors/:id', routes.getGovernorById);
 app.get('/v1/congress', routes.getCongressMembers);
+app.get('/v1/congress/:id', routes.getCongressMemberById);
 
 // Catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,12 @@ var config = convict({
             format: String,
             default: 'governors',
             env: 'GOV_COLLECTION'
+        },
+        congress_collection: {
+            doc: 'Congress collection name',
+            format: String,
+            default: 'congress',
+            env: 'CONGRESS_COLLECTION'
         }
     }
 });

--- a/src/local_config.json
+++ b/src/local_config.json
@@ -3,7 +3,8 @@
         "host": "localhost",
         "port": 27017,
         "name": "elected_officials",
-        "gov_collection": "governors"
+        "gov_collection": "governors",
+        "congress_collection": "congress"
     },
     "app": {
         "host": "localhost",

--- a/src/routes.js
+++ b/src/routes.js
@@ -69,3 +69,11 @@ exports.getGovernorById = function(req, res) {
         res.json(queryResults(err, doc));
 	});
 };
+
+exports.getCongressMembers = function(req, res) {
+    var db = req.db;
+    var collection = db.get(config.get('database.congress_collection'));
+    collection.find({}, fields, function(err, docs) {
+        res.json(queryResults(err, docs));
+    });
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,6 +44,41 @@ var processGovernorQuery = function(query) {
     return query;
 };
 
+var processCongressQuery = function(query) {
+    var newQuery = query;
+
+    if (query.state) {
+        // We want 'state' to be flexible in terms of what it accepts as a
+        // valid parameter as well as keep our search syntax somewhat
+        // similar to /governor queries.
+
+        // We're introducting an intentional bias towards the 'state' param.
+        // If present in 'query', we will attempt to normalize 'newQuery' based
+        // on the value of 'query.state' and update 'newQuery' accordingly.
+        if (query.state.length === 2) {
+            newQuery.state = query.state.toUpperCase();
+            delete newQuery.state_name;
+        } else {
+            newQuery.state_name = query.state.capitalize();
+            delete newQuery.state;
+        }
+    }
+
+    if (query.party){
+        var reRep = /republicans?\b/i;
+        var reDem = /democrats?\b/i;
+        var reInd = /independents?\b/i;
+
+        newQuery.party = query.party.toUpperCase();
+        
+        reRep.test(query.party) ? newQuery.party = "R" : newQuery;
+        reDem.test(query.party) ? newQuery.party = "D" : newQuery;
+        reInd.test(query.party) ? newQuery.party = "I" : newQuery;
+    }
+
+    return newQuery;
+};
+
 exports.appRoot = function(req, res) {
     res.send('Welcome to the Elected Officials API!');
 };
@@ -74,9 +109,18 @@ exports.getGovernorById = function(req, res) {
 exports.getCongressMembers = function(req, res) {
     var db = req.db;
     var collection = db.get(config.get('database.congress_collection'));
-    collection.find({}, fields, function(err, docs) {
-        res.json(queryResults(err, docs));
-    });
+
+    if (_.isEmpty(req.query)) {
+        collection.find({}, fields, function(err, docs) {
+            res.json(queryResults(err, docs));
+        });
+    } else {
+        collection.find(processCongressQuery(req.query), fields,
+            function(err, docs) {
+                res.json(queryResults(err, docs));
+            }
+        );
+    }
 };
 
 exports.getCongressMemberById = function(req, res) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,7 +10,8 @@ var fields = ['-_id'];
 
 var queryResults = function(err, results) {
     if (!results) {
-        return {results: "Something really bad happened. Try again later."}
+        console.error(err);
+        return {results: "Something really bad happened. Try again later."};
     }
 
     if (results.length === 0) {
@@ -65,7 +66,7 @@ exports.getGovernors = function(req, res) {
 exports.getGovernorById = function(req, res) {
 	var db = req.db;
 	var collection = db.get(config.get('database.gov_collection'));
-	collection.findOne({ '_id': req.params.id }, ['-_id'], function(err, doc) {
+	collection.findOne({ '_id': req.params.id }, fields, function(err, doc) {
         res.json(queryResults(err, doc));
 	});
 };
@@ -76,4 +77,12 @@ exports.getCongressMembers = function(req, res) {
     collection.find({}, fields, function(err, docs) {
         res.json(queryResults(err, docs));
     });
+};
+
+exports.getCongressMemberById = function(req, res) {
+    var db = req.db;
+    var collection = db.get(config.get('database.congress_collection'));
+    collection.findOne({ '_id': req.params.id }, fields, function(err, doc) {
+        res.json(queryResults(err, doc));
+	});
 };

--- a/src/test_config.json
+++ b/src/test_config.json
@@ -3,10 +3,11 @@
         "host": "localhost",
         "port": 27017,
         "name": "test_elected_officials",
-        "gov_collection": "test_governors"
+        "gov_collection": "test_governors",
+        "congress_collection": "test_congress"
     },
     "app": {
         "host": "localhost",
-        "port": 3000
+        "port": 3001
     }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -31,27 +31,29 @@ describe('Helper methods', function() {
     });
 });
 
-describe('Test DB setup and structure', function() {
-    var db,
-        collection;
-
-    before(function (done) {
-        db = monk(db_uri);
-        collection = db.get(config.get('database.gov_collection'));
-        done();
-    });
-    after(function (done) {
-        db.close(done);
-    });
-    it("connect and initialize db", function (done) {
-        should.exist(db);
-        done();
-    });
-    it("collections exist", function (done) {
-        should.exist(collection);
-        done();
-    });
-});
+// describe('Test DB setup and structure', function() {
+//     var db,
+//         collection;
+//
+//     before(function (done) {
+//         db = monk(db_uri);
+//         debugger;
+//         collection = db.get(config.get('database.gov_collection'));
+//         done();
+//     });
+//     after(function (done) {
+//         db.close(done);
+//     });
+//     it("connect and initialize db", function (done) {
+//         debugger;
+//         should.exist(db);
+//         done();
+//     });
+//     it("collections exist", function (done) {
+//         should.exist(collection);
+//         done();
+//     });
+// });
 
 describe('Test API endpoints', function() {
     var server;
@@ -77,8 +79,8 @@ describe('Test API endpoints', function() {
     it('server responds to /congress', function(done) {
         request(server)
             .get('/v1/congress')
-            .expect(200, done)
-    })
+            .expect(200, done);
+    });
     it('404 on routes that don\'t exist', function(done) {
         request(server)
             .get('/sultans')
@@ -95,14 +97,7 @@ describe('Test endpoints that accept params', function() {
     // TODO: If db isn't running, this may fail with a really unhelpful message.
     before(function (done) {
         db = monk(db_uri);
-        collection = db.get(config.get('database.gov_collection'));
-        collection.insert( {name: 'test_document'}, function(err, docs) {
-            if (err) {
-                return err;
-            }
-            doc = docs;
-            done();
-        });
+        done();
     });
     after(function (done) {
         collection.drop(function (err) {
@@ -120,8 +115,27 @@ describe('Test endpoints that accept params', function() {
         server.close(done);
     });
     it('can call a governor resource by id', function(done) {
+        collection = db.get(config.get('database.gov_collection'));
+        collection.insert( {name: 'test_document'}, function(err, docs) {
+            if (err) {
+                return err;
+            }
+            doc = docs;
+        });
         request(server)
-            .get('/v1/governors/' + doc['_id'])
+            .get('/v1/governors/' + doc._id)
+            .expect(200, done);
+    });
+    it('can call a congress resource by id', function(done) {
+        collection = db.get(config.get('database.congress_collection'));
+        collection.insert( {name: 'test_document'}, function(err, docs) {
+            if (err) {
+                return err;
+            }
+            doc = docs;
+        });
+        request(server)
+            .get('/v1/congress/' + doc['_id'])
             .expect(200, done);
     });
 });


### PR DESCRIPTION
Added two new API endpoints: `/congress` and `/congress/:id`.

Notables:
1. Both endpoints only accept GET requests.
2. Both endpoints only return JSON.
3. `/congress` can be passed any query parameters present in a Congress document.
4. Most query parameters are simply passed straight through, but the `state` and `party` parameters are validated and processed before sending the query.
- `state` can accept either the full state name or state abbreviation and is case insensitive. (Note: if `state_name` is passed as a query param, it will only be treated as case insensitive if passed along with the `state` param. It is recommended that you use `state` only.)
- `party` is case insenstive and accepts either the full party name (ie. Republican or Republicans) or the first letter.
